### PR TITLE
Submit event on run

### DIFF
--- a/cmd/nri-process-discovery.go
+++ b/cmd/nri-process-discovery.go
@@ -78,22 +78,28 @@ func main() {
 		}
 	}
 
+	if err = event(i, processesDiscovered, runID); err != nil {
+		l.Errorf(err.Error())
+	}
+}
+
+func event(i *integration.Integration, processesDiscovered int, runID string) error {
 	e, err := i.NewEvent(time.Now(), "dynamic_instrumentation", "start_process_discovery")
 	if err != nil {
-		l.Errorf("cannot create event, error: %s", err.Error())
-		return
+		return fmt.Errorf("cannot create event, error: %s", err.Error())
 	}
 
 	err = e.AddAttribute("processes.discovered", processesDiscovered)
 	if err != nil {
-		l.Errorf("cannot add attribute to event, error: %s", err.Error())
+		return fmt.Errorf("cannot add attribute to event, error: %s", err.Error())
 	}
 	err = e.AddAttribute("run.id", runID)
 	if err != nil {
-		l.Errorf("cannot add attribute to event, error: %s", err.Error())
+		return fmt.Errorf("cannot add attribute to event, error: %s", err.Error())
 	}
 
 	i.HostEntity.AddEvent(e)
+	return nil
 }
 
 func newSingleCmdReqPayload(integrationName string, pid int32, runID string) (payload string, err error) {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/go-ole/go-ole v1.2.4 // indirect
-	github.com/newrelic/infra-integrations-sdk v1.0.1-0.20200907091437-3448c6399fd2
+	github.com/newrelic/infra-integrations-sdk v1.0.1-0.20201016141521-6fdfe28ad6c0
 	github.com/newrelic/infrastructure-agent v0.0.0-20201015152526-4100d6be50f3
 	github.com/shirou/gopsutil v2.20.8+incompatible
 	github.com/stretchr/testify v1.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7P
 github.com/newrelic/infra-identity-client-go v1.0.2/go.mod h1:lrG2ompP2Mr6D8WW615/h2AYNs9B9pw2zLuc38LNb4E=
 github.com/newrelic/infra-integrations-sdk v1.0.1-0.20200907091437-3448c6399fd2 h1:I/SM8ymHVdbDpDuOIf3Km/+YVw3P9MeOjkwH1KrVHCk=
 github.com/newrelic/infra-integrations-sdk v1.0.1-0.20200907091437-3448c6399fd2/go.mod h1:pkt52iL985phO3d+kREkalNFJdjYyccUDTD+IK/Pno8=
+github.com/newrelic/infra-integrations-sdk v1.0.1-0.20201016141521-6fdfe28ad6c0 h1:E+vVSdCOVKDryTQNKrsHxAh4GeeCWPfZWZ7vMDRbvlo=
+github.com/newrelic/infra-integrations-sdk v1.0.1-0.20201016141521-6fdfe28ad6c0/go.mod h1:pkt52iL985phO3d+kREkalNFJdjYyccUDTD+IK/Pno8=
 github.com/newrelic/infrastructure-agent v0.0.0-20201015152526-4100d6be50f3 h1:UgFTlLhZI9W6o6U8m7fHR2LHJdja97c4E9qzStcP3Xg=
 github.com/newrelic/infrastructure-agent v0.0.0-20201015152526-4100d6be50f3/go.mod h1:aHTtUYBCLvWb3/GkGPTD24flzYSmf728qFH4tDI4DNA=
 github.com/opencontainers/go-digest v1.0.0-rc1.0.20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=


### PR DESCRIPTION
Subtle instrumentation so process-discovery run submits its results as telemetry event.

Final payload now mixes integration-run-requests & telemetry data, ie:

```
{
  "command_request_version": "1",
  "commands": [
    {
      "name": "nri-lsi-java",
      "command": "",
      "args": [
        "-introspect",
        "51596",
        "-runID",
        "1605113800102166000"
      ],
      "env": null
    }
  ]
}
{
  "protocol_version": "4",
  "integration": {
    "name": "com.new-relic.nri-process-discovery",
    "version": "0.0.0"
  },
  "data": [
    {
      "common": {},
      "metrics": [],
      "inventory": {},
      "events": [
        {
          "timestamp": 1605113800,
          "summary": "dynamic_instrumentation",
          "category": "start_process_discovery",
          "attributes": {
            "processes.discovered": 1,
            "run.id": "1605113800102166000"
          }
        }
      ]
    }
  ]
}
```